### PR TITLE
add configuration to force update the node.js runtime 

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -213,3 +213,7 @@ resources:
           - COGNITO
         UserPoolId:
           Ref: UserPool
+  extensions:
+    CustomDashresourceDashexistingDashs3LambdaFunction:
+      Properties:
+        Runtime: nodejs20.x


### PR DESCRIPTION
Serverless v3 have lambda function to handle condition if we want to use existing s3 bucket. The runtime for that particular lambda is hardcoded to use node.js 16 that will be deprecated September 2025. As workaround for this until the code can be migrated to use serverless v4, I add additional configuration that force the runtime upgrade node.js 20.